### PR TITLE
Remove whitespace: no-wrap from the name display

### DIFF
--- a/client/src/scss/pages/_lobby.scss
+++ b/client/src/scss/pages/_lobby.scss
@@ -134,7 +134,6 @@ $users-width: 18rem;
 
       .name {
         text-overflow: ellipsis;
-        white-space: nowrap;
         overflow: hidden;
       }
     }


### PR DESCRIPTION
So we can see our friends funny long names without having to hover it.