### PR TITLE
remove word-break: break-all

### DIFF
--- a/client/src/scss/_cards.scss
+++ b/client/src/scss/_cards.scss
@@ -52,7 +52,6 @@ $response-background: $call-color;
       span {
         white-space: pre-wrap;
         overflow-wrap: break-word;
-        word-break: break-all;
       }
 
       .text {


### PR DESCRIPTION
Otherwise leads to weird display like

![image](https://user-images.githubusercontent.com/10828874/82839134-a19b9100-9ece-11ea-905a-e2bab7e43fb0.png)
