### PR TITLE
Fix minor issues with Polish translation.

### DIFF
--- a/client/src/elm/MassiveDecks/Strings/Languages/Pl.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/Pl.elm
@@ -1209,7 +1209,7 @@ translate maybeDeclCase mdString =
         ErrorCheckOutOfBand ->
             [ Text "Prosimy sprawdzić aktualizacje i status na "
             , ref TwitterHandle
-            , Text ". Serwery gry są wyłączane na krótki czas podczas aktualizacji, więc jeśli taka nastąpiła ostatnio,"
+            , Text ". Serwery gry są wyłączane na krótki czas podczas aktualizacji, więc jeśli taka nastąpiła ostatnio, "
             , Text "spróbuj ponownie za kilka minut."
             ]
 
@@ -1286,7 +1286,7 @@ translate maybeDeclCase mdString =
             [ Text "Twoje dane dostępu do gry są uszkodzone." ]
 
         InvalidLobbyPasswordError ->
-            [ Text "Podane hasło gry jest nieprawidłowe. Spróbuj wpisać je jeszcze raz, i jeśli to nie zadziała,"
+            [ Text "Podane hasło gry jest nieprawidłowe. Spróbuj wpisać je jeszcze raz, i jeśli to nie zadziała, "
             , Text "zapytaj znów osobę która cię zaprosiła."
             ]
 
@@ -1344,7 +1344,7 @@ translate maybeDeclCase mdString =
             [ Text "Polski" ]
 
         Indonesian ->
-            [ Text "Indonezyjsku" ]
+            [ Text "Indonezyski" ]
 
 
 type DeclensionCase


### PR DESCRIPTION
# Description
Resolves minor issues with Polish translation outlined #178.
> There are some tiny issues in the Polish translation I noticed. They're really tiny and quick to fix so I don't even bother creating a separate issue: there are missing spaces after colons on lines 1212 and 1289 in the current master branch
Originally posted by @TheChilliPL in #172 (comment)
Also, Indonesian in Polish is Indonezyski, I presume the automatic translator messed that up, as it sometimes does
Originally posted by @TheChilliPL in #172 (comment)