### PR TITLE
Fix heroku build

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,4 @@
+client=https://github.com/heroku/heroku-buildpack-nodejs.git
+server=https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-nginx.git

--- a/app.json
+++ b/app.json
@@ -5,10 +5,7 @@
   "keywords": ["game", "party", "comedy"],
   "buildpacks": [
     {
-      "url": "https://github.com/heroku/heroku-buildpack-nginx.git"
-    },
-    {
-      "url": "https://github.com/heroku/heroku-buildpack-nodejs.git"
+      "url": "https://github.com/negativetwelve/heroku-buildpack-subdir.git"
     }
   ],
   "env": {

--- a/package.json
+++ b/package.json
@@ -7,15 +7,9 @@
   "private": true,
   "repository": "github:Lattyware/massivedecks",
   "engines": {
-    "node": "14.x.x"
+    "node": "15.x.x"
   },
   "scripts": {
-    "build": "cp -r server/decks decks && npm run buildServer && npm run buildClient",
-    "buildServer": "npm explore @massivedecks/server -- npm run build",
-    "buildClient": "npm explore @massivedecks/client -- npm run build"
-  },
-  "dependencies": {
-    "@massivedecks/server": "file:./server",
-    "@massivedecks/client": "file:./client"
+    "build": "cp -r server/decks decks"
   }
 }


### PR DESCRIPTION
Fix heroku build by using https://github.com/negativetwelve/heroku-buildpack-subdir.git and building client and server separately.

Fixes https://github.com/Lattyware/massivedecks/issues/176.