### PR TITLE
Add Winner's Pick House Rule

### DIFF
--- a/client/src/elm/MassiveDecks/Game/Rules.elm
+++ b/client/src/elm/MassiveDecks/Game/Rules.elm
@@ -11,6 +11,7 @@ module MassiveDecks.Game.Rules exposing
     , Stage
     , Stages
     , TimeLimitMode(..)
+    , WinnersPick
     )
 
 {-| Game rules.
@@ -35,6 +36,7 @@ type alias HouseRules =
     , neverHaveIEver : Maybe NeverHaveIEver
     , happyEnding : Maybe HappyEnding
     , czarChoices : Maybe CzarChoices
+    , winnersPick : Maybe WinnersPick
     }
 
 
@@ -88,3 +90,7 @@ type alias CzarChoices =
     { numberOfChoices : Int
     , custom : Bool
     }
+
+
+type alias WinnersPick =
+    {}

--- a/client/src/elm/MassiveDecks/Models/Decoders.elm
+++ b/client/src/elm/MassiveDecks/Models/Decoders.elm
@@ -433,6 +433,7 @@ houseRules =
         |> Json.optional "neverHaveIEver" (neverHaveIEver |> Json.map Just) Nothing
         |> Json.optional "happyEnding" (happyEnding |> Json.map Just) Nothing
         |> Json.optional "czarChoices" (czarChoices |> Json.map Just) Nothing
+        |> Json.optional "winnersPick" (winnersPick |> Json.map Just) Nothing
 
 
 comedyWriter : Json.Decoder Rules.ComedyWriter
@@ -462,6 +463,11 @@ czarChoices =
     Json.succeed Rules.CzarChoices
         |> Json.required "numberOfChoices" Json.int
         |> Json.optional "custom" Json.bool False
+
+
+winnersPick : Json.Decoder Rules.WinnersPick
+winnersPick =
+    {} |> Json.succeed
 
 
 reboot : Json.Decoder Rules.Reboot

--- a/client/src/elm/MassiveDecks/Models/Encoders.elm
+++ b/client/src/elm/MassiveDecks/Models/Encoders.elm
@@ -123,6 +123,7 @@ houseRules h =
             , h.neverHaveIEver |> Maybe.map (\n -> ( "neverHaveIEver", neverHaveIEver n ))
             , h.happyEnding |> Maybe.map (\e -> ( "happyEnding", happyEnding e ))
             , h.czarChoices |> Maybe.map (\c -> ( "czarChoices", czarChoices c ))
+            , h.winnersPick |> Maybe.map (\w -> ( "winnersPick", winnersPick w ))
             ]
         )
 
@@ -168,6 +169,11 @@ czarChoices { numberOfChoices, custom } =
                 []
     in
     (( "numberOfChoices", numberOfChoices |> Json.int ) :: rest) |> Json.object
+
+
+winnersPick : Rules.WinnersPick -> Json.Value
+winnersPick _ =
+    Json.object []
 
 
 decks : Decks.Config -> Json.Value

--- a/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Model.elm
+++ b/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Model.elm
@@ -73,6 +73,7 @@ fake =
             , neverHaveIEver = Nothing
             , happyEnding = Nothing
             , czarChoices = Nothing
+            , winnersPick = Nothing
             }
         , stages =
             { mode = Rules.Soft

--- a/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Rules/HouseRules.elm
+++ b/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Rules/HouseRules.elm
@@ -13,6 +13,7 @@ import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.NeverHaveIEver as Nev
 import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.PackingHeat as PackingHeat
 import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.Rando as Rando
 import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.Reboot as Reboot
+import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.WinnersPick as WinnersPick
 import MassiveDecks.Strings as Strings
 
 
@@ -29,5 +30,6 @@ all wrap =
             , NeverHaveIEver.all |> Configurable.wrap NeverHaveIEverId (.neverHaveIEver >> Just) (\v p -> { p | neverHaveIEver = v })
             , HappyEnding.all |> Configurable.wrap HappyEndingId (.happyEnding >> Just) (\v p -> { p | happyEnding = v })
             , CzarChoices.all wrap |> Configurable.wrap CzarChoicesId (.czarChoices >> Just) (\v p -> { p | czarChoices = v })
+            , WinnersPick.all |> Configurable.wrap WinnersPickId (.winnersPick >> Just) (\v p -> { p | winnersPick = v })
             ]
         }

--- a/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Rules/HouseRules/Model.elm
+++ b/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Rules/HouseRules/Model.elm
@@ -7,6 +7,7 @@ import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.NeverHaveIEver.Model 
 import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.PackingHeat.Model as PackingHeat
 import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.Rando.Model as Rando
 import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.Reboot.Model as Reboot
+import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.WinnersPick.Model as WinnersPick
 
 
 type Id
@@ -18,3 +19,4 @@ type Id
     | NeverHaveIEverId NeverHaveIEver.Id
     | HappyEndingId HappyEnding.Id
     | CzarChoicesId CzarChoices.Id
+    | WinnersPickId WinnersPick.Id

--- a/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Rules/HouseRules/WinnersPick.elm
+++ b/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Rules/HouseRules/WinnersPick.elm
@@ -1,0 +1,31 @@
+module MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.WinnersPick exposing (all)
+
+import MassiveDecks.Components.Form.Message as Message
+import MassiveDecks.Game.Rules as Rules
+import MassiveDecks.Pages.Lobby.Configure.Configurable as Configurable
+import MassiveDecks.Pages.Lobby.Configure.Configurable.Editor as Editor
+import MassiveDecks.Pages.Lobby.Configure.Configurable.Model exposing (Configurable)
+import MassiveDecks.Pages.Lobby.Configure.Configurable.Validator as Validator
+import MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.WinnersPick.Model exposing (..)
+import MassiveDecks.Strings as Strings
+
+
+all : Configurable Id (Maybe Rules.WinnersPick) model msg
+all =
+    Configurable.group
+        { id = All
+        , editor = Editor.group "winners-pick" Nothing False False
+        , children =
+            [ enabled |> Configurable.wrapAsToggle {}
+            ]
+        }
+
+
+enabled : Configurable Id Bool model msg
+enabled =
+    Configurable.value
+        { id = Enabled
+        , editor = Editor.bool Strings.HouseRuleWinnersPick
+        , validator = Validator.none
+        , messages = always [ Message.info Strings.HouseRuleWinnersPickDescription ]
+        }

--- a/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Rules/HouseRules/WinnersPick/Model.elm
+++ b/client/src/elm/MassiveDecks/Pages/Lobby/Configure/Rules/HouseRules/WinnersPick/Model.elm
@@ -1,0 +1,6 @@
+module MassiveDecks.Pages.Lobby.Configure.Rules.HouseRules.WinnersPick.Model exposing (Id(..))
+
+
+type Id
+    = All
+    | Enabled

--- a/client/src/elm/MassiveDecks/Pages/Start.elm
+++ b/client/src/elm/MassiveDecks/Pages/Start.elm
@@ -585,6 +585,7 @@ houseRules =
     , ( Strings.HouseRuleComedyWriter, Strings.HouseRuleComedyWriterDescription )
     , ( Strings.HouseRuleNeverHaveIEver, Strings.HouseRuleNeverHaveIEverDescription )
     , ( Strings.HouseRuleHappyEnding, Strings.HouseRuleHappyEndingDescription )
+    , ( Strings.HouseRuleWinnersPick, Strings.HouseRuleWinnersPickDescription )
     ]
 
 

--- a/client/src/elm/MassiveDecks/Strings.elm
+++ b/client/src/elm/MassiveDecks/Strings.elm
@@ -124,6 +124,8 @@ type MdString
     | HouseRuleCzarChoicesNumberDescription -- A description of the setting for the number of choices the czar is given.
     | HouseRuleCzarChoicesCustom -- A name of the setting for allowing the czar to write a custom call.
     | HouseRuleCzarChoicesCustomDescription -- A description of the setting for allowing the czar to write a custom call.
+    | HouseRuleWinnersPick -- The name of the house rule where the winner of each round becomes the next czar.
+    | HouseRuleWinnersPickDescription -- A description of the house rule where the winner of each round becomes the next czar.
     | SeeAlso { rule : MdString } -- A message telling the user to see another rule.
     | MustBeMoreThanOrEqualValidationError { min : Int } -- An error when a configuration value must be more than or equal to the given value.
     | MustBeLessThanOrEqualValidationError { max : Int } -- An error when a configuration value must be less than or equal to the given value.
@@ -418,4 +420,3 @@ type MdString
     | Polish -- The name of the Polish language.
     | Indonesian -- The name of the Indonesian language.
     | Spanish -- The name of the Spanish language.
-    

--- a/client/src/elm/MassiveDecks/Strings/Languages/De.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/De.elm
@@ -10,6 +10,7 @@ Contributors:
 
 import MassiveDecks.Card.Source.BuiltIn.Model as BuiltIn
 import MassiveDecks.Card.Source.Model as Source
+import MassiveDecks.Game.Rules exposing (WinnersPick)
 import MassiveDecks.Strings exposing (MdString(..), Noun(..), Quantity(..), noun, nounMaybe, nounUnknownQuantity)
 import MassiveDecks.Strings.Languages.Model exposing (Language(..))
 import MassiveDecks.Strings.Translation as Translation
@@ -376,6 +377,14 @@ translate _ mdString =
 
         -- TODO: Translate
         HouseRuleCzarChoicesCustomDescription ->
+            [ Missing ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPick ->
+            [ Missing ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPickDescription ->
             [ Missing ]
 
         -- TODO: Translate
@@ -1358,7 +1367,7 @@ translate _ mdString =
 
         Indonesian ->
             [ Text "Indonesisch" ]
-            
+
         Spanish ->
             [ Text "Spanisch" ]
 

--- a/client/src/elm/MassiveDecks/Strings/Languages/DeXInformal.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/DeXInformal.elm
@@ -379,6 +379,14 @@ translate _ mdString =
             [ Missing ]
 
         -- TODO: Translate
+        HouseRuleWinnersPick ->
+            [ Missing ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPickDescription ->
+            [ Missing ]
+
+        -- TODO: Translate
         SeeAlso { rule } ->
             [ Missing ]
 
@@ -1357,7 +1365,7 @@ translate _ mdString =
 
         Indonesian ->
             [ Text "Indonesisch" ]
-            
+
         Spanish ->
             [ Text "Spanisch" ]
 

--- a/client/src/elm/MassiveDecks/Strings/Languages/En/Internal.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/En/Internal.elm
@@ -330,6 +330,12 @@ translate _ mdString =
         HouseRuleCzarChoicesCustomDescription ->
             [ Text "If the ", ref Czar, Text " can write custom calls. This takes up one of the choices." ]
 
+        HouseRuleWinnersPick ->
+            [ Text "Winner's Pick" ]
+
+        HouseRuleWinnersPickDescription ->
+            [ Text "The winner of each round becomes the ", ref Czar, Text " for the next round." ]
+
         SeeAlso { rule } ->
             [ Text "See also: ", ref rule ]
 
@@ -1308,7 +1314,7 @@ translate _ mdString =
 
         Indonesian ->
             [ Text "Indonesian" ]
-            
+
         Spanish ->
             [ Text "Spanish" ]
 

--- a/client/src/elm/MassiveDecks/Strings/Languages/Es.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/Es.elm
@@ -352,6 +352,14 @@ translate _ mdString =
         HouseRuleCzarChoicesCustomDescription ->
             [ Text "Si el ", ref Czar, Text " puede escribir cartas personalizadas. Esto eliminará una de las elecciones." ]
 
+        -- TODO: Translate
+        HouseRuleWinnersPick ->
+            [ Missing ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPickDescription ->
+            [ Missing ]
+
         SeeAlso { rule } ->
             [ Text "Ver también: ", ref rule ]
 

--- a/client/src/elm/MassiveDecks/Strings/Languages/Id.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/Id.elm
@@ -369,6 +369,14 @@ translate _ mdString =
             [ Missing ]
 
         -- TODO: Translate
+        HouseRuleWinnersPick ->
+            [ Missing ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPickDescription ->
+            [ Missing ]
+
+        -- TODO: Translate
         SeeAlso { rule } ->
             [ Missing ]
 

--- a/client/src/elm/MassiveDecks/Strings/Languages/It.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/It.elm
@@ -383,6 +383,14 @@ translate _ mdString =
             [ Missing ]
 
         -- TODO: Translate
+        HouseRuleWinnersPick ->
+            [ Missing ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPickDescription ->
+            [ Missing ]
+
+        -- TODO: Translate
         SeeAlso { rule } ->
             [ Missing ]
 

--- a/client/src/elm/MassiveDecks/Strings/Languages/Pl.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/Pl.elm
@@ -393,7 +393,8 @@ translate maybeDeclCase mdString =
             , ref Czar
             , Text " otrzymuje wiele "
             , refDecl Genitive (nounUnknownQuantity Call)
-            , Text " i może wybrać jedną z nich, i/lub może napisać własną."]
+            , Text " i może wybrać jedną z nich, i/lub może napisać własną."
+            ]
 
         HouseRuleCzarChoicesNumber ->
             [ Text "Ilość" ]
@@ -406,6 +407,14 @@ translate maybeDeclCase mdString =
 
         HouseRuleCzarChoicesCustomDescription ->
             [ Text "Czy ", ref Czar, Text " może pisać własne czarne karty. Zabiera miejsce jednego z wyborów." ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPick ->
+            [ Missing ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPickDescription ->
+            [ Missing ]
 
         SeeAlso { rule } ->
             [ Text "Zobacz także: ", ref rule ]
@@ -1730,9 +1739,17 @@ asWord number gender declCase =
 
         1 ->
             {- We assume feminine accusative is the only non-nominative case we need.
-            It's true for now and implementing other cases would take more code.
+               It's true for now and implementing other cases would take more code.
             -}
-            dependingOnGender "jeden" (if declCase == Accusative then "jedną" else "jedna") "jedno" gender
+            dependingOnGender "jeden"
+                (if declCase == Accusative then
+                    "jedną"
+
+                 else
+                    "jedna"
+                )
+                "jedno"
+                gender
 
         2 ->
             dependingOnGender "dwa" "dwie" "dwa" gender

--- a/client/src/elm/MassiveDecks/Strings/Languages/PtBR.elm
+++ b/client/src/elm/MassiveDecks/Strings/Languages/PtBR.elm
@@ -377,6 +377,14 @@ translate _ mdString =
             [ Missing ]
 
         -- TODO: Translate
+        HouseRuleWinnersPick ->
+            [ Missing ]
+
+        -- TODO: Translate
+        HouseRuleWinnersPickDescription ->
+            [ Missing ]
+
+        -- TODO: Translate
         SeeAlso { rule } ->
             [ Missing ]
 

--- a/client/src/elm/MassiveDecks/Strings/Render.elm
+++ b/client/src/elm/MassiveDecks/Strings/Render.elm
@@ -216,6 +216,9 @@ enhanceHtml shared context mdString unenhanced =
         HouseRuleCzarChoices ->
             prefixed unenhanced Icon.clipboardList
 
+        HouseRuleWinnersPick ->
+            prefixed unenhanced Icon.trophy
+
         RereadGames ->
             [ Html.blankA [ HtmlA.class "no-wrap", HtmlA.href "https://www.rereadgames.com/" ] unenhanced ]
 

--- a/deployment/postgres/config.json5
+++ b/deployment/postgres/config.json5
@@ -63,7 +63,8 @@
         // comedyWriter: { number: 300, exclusive: true },
         // rando: { number: 1 },
         // neverHaveIEver: {},
-        // happyEnding: {}
+        // happyEnding: {},
+        // winnersPick: {},
       },
       stages: {
         timeLimitMode: "Soft",

--- a/server/config.json5
+++ b/server/config.json5
@@ -63,7 +63,8 @@
         // comedyWriter: { number: 300, exclusive: true },
         // rando: { number: 1 },
         // neverHaveIEver: {},
-        // happyEnding: {}
+        // happyEnding: {},
+        // winnersPick: {},
       },
       stages: {
         timeLimitMode: "Soft",

--- a/server/src/ts/action/game-action/czar/judge.ts
+++ b/server/src/ts/action/game-action/czar/judge.ts
@@ -49,6 +49,9 @@ class JudgeAction extends Actions.Implementation<
       }
       const player = game.players[winningPlay.playedBy];
       player.score += 1;
+      if (game.rules.houseRules.winnersPick) {
+        game.rules.houseRules.winnersPick.roundWinner = winningPlay.playedBy;
+      }
       const completedRound = round.advance(winningPlay.playedBy);
       game.round = completedRound;
       game.history.splice(0, 0, completedRound.public());

--- a/server/src/ts/action/validation.validator.ts
+++ b/server/src/ts/action/validation.validator.ts
@@ -695,6 +695,9 @@ export const Schema = {
         reboot: {
           $ref: "#/definitions/Reboot",
         },
+        winnersPick: {
+          $ref: "#/definitions/WinnersPick",
+        },
       },
       type: "object",
     },
@@ -1103,6 +1106,17 @@ export const Schema = {
     Token: {
       description: "A token that contains the encoded claims of a user.",
       type: "string",
+    },
+    WinnersPick: {
+      $ref: "#/definitions/WinnersPick_1",
+      description:
+        'Configuration for the "Winner\'s Pick" house rule.\nThis rule makes the winner of each round the czar for the next round.',
+    },
+    WinnersPick_1: {
+      additionalProperties: false,
+      description:
+        'Configuration for the "Winner\'s Pick" house rule.\nThis rule makes the winner of each round the czar for the next round.',
+      type: "object",
     },
   },
 };

--- a/server/src/ts/games/game.ts
+++ b/server/src/ts/games/game.ts
@@ -112,6 +112,15 @@ export class Game {
   }
 
   public nextCzar(users: { [id: string]: User.User }): User.Id | undefined {
+    if (
+      this.rules.houseRules.winnersPick &&
+      this.rules.houseRules.winnersPick.roundWinner
+    ) {
+      const roundWinner = this.rules.houseRules.winnersPick.roundWinner;
+      if (Game.canBeCzar(users[roundWinner], this.players[roundWinner])) {
+        return roundWinner;
+      }
+    }
     const current = this.round.czar;
     const playerOrder = this.playerOrder;
     const currentIndex = playerOrder.findIndex((id) => id === current);

--- a/server/src/ts/games/rules.ts
+++ b/server/src/ts/games/rules.ts
@@ -132,6 +132,12 @@ export interface ComedyWriter {
  */
 export interface NeverHaveIEver {}
 
+/**
+ * Configuration for the "Winner's Pick" house rule.
+ * This rule makes the winner of each round the czar for the next round.
+ */
+export interface WinnersPick {}
+
 export const censor = (rules: Rules): Public => ({
   ...rules,
   houseRules: HouseRules.censor(rules.houseRules),

--- a/server/src/ts/games/rules/house-rules.ts
+++ b/server/src/ts/games/rules/house-rules.ts
@@ -2,6 +2,7 @@ import { PackingHeat, Reboot, ComedyWriter, NeverHaveIEver } from "../rules";
 import * as Rando from "./rando";
 import * as HappyEnding from "./happy-ending";
 import * as CzarChoices from "./czar-choices";
+import * as WinnersPick from "./winners-pick";
 
 /**
  * Non-standard rules that can be applied to a game.
@@ -14,6 +15,7 @@ export interface HouseRules {
   neverHaveIEver?: NeverHaveIEver;
   happyEnding?: HappyEnding.HappyEnding;
   czarChoices?: CzarChoices.CzarChoices;
+  winnersPick?: WinnersPick.WinnersPick;
 }
 
 /**
@@ -27,6 +29,7 @@ export interface Public {
   neverHaveIEver?: NeverHaveIEver;
   happyEnding?: HappyEnding.HappyEnding;
   czarChoices?: CzarChoices.CzarChoices;
+  winnersPick?: WinnersPick.WinnersPick;
 }
 
 export const censor = (houseRules: HouseRules): Public => ({

--- a/server/src/ts/games/rules/winners-pick.ts
+++ b/server/src/ts/games/rules/winners-pick.ts
@@ -1,0 +1,7 @@
+/**
+ * Configuration for the "Winner's Pick" house rule.
+ * This rule makes the winner of each round the czar for the next round.
+ */
+export interface WinnersPick {
+  roundWinner?: string;
+}


### PR DESCRIPTION
Resolves #222
> After the Czar chooses the winner, the winner gets to be the Czar in the next round.

This PR adds a new rule called *Winner's Pick*, which makes the winner of the previous round the new card czar for the next round. Rather than making the rule incompatible with AIs, if an AI wins a round, the next czar is picked the using normal method of selecting the next human player.